### PR TITLE
タグを . で分割して部分的に置換可能にする

### DIFF
--- a/lib/fluent/plugin/out_forest.rb
+++ b/lib/fluent/plugin/out_forest.rb
@@ -50,8 +50,17 @@ class Fluent::ForestOutput < Fluent::Output
 
   def parameter(tag, e)
     pairs = {}
+    tags = tag.split('.')
     e.each do |k,v|
       pairs[k] = v.gsub('__TAG__', tag).gsub('${tag}', tag).gsub('__HOSTNAME__', @hostname).gsub('${hostname}', @hostname)
+      pairs[k].gsub!(/\$\{tag\[([-+.\d]+)\]\}/) do |match|
+        begin
+          r = eval("tags[#{$1}]")
+          r.instance_of?(Array) ? r.join('.') : r
+        rescue SyntaxError
+          match
+        end
+      end
     end
     Fluent::Config::Element.new('instance', '', pairs, [])
   end


### PR DESCRIPTION
タグを `.` で分割して置換する機能の追加要望です。

${tag} のようにタグ全体を埋め込むのではなく、タグの一部だけを埋め込みたいことがあります。
例えば、ファイル出力時にタグの階層に従ってディレクトリを分割する利用法があります。

分割した各項目を取り出す構文はお任せしますが、仮に ${tag[N]} (N は 0 origin) とすると、
`tag: file.var.log.supervisor.fluentd.log` を `/tmp/fluentd/supervisor/fluentd.log` に保存するために以下のように設定できると嬉しいです。

```
<match file.var.log.**>
  type forest
  subtype file
  <template>
    path /tmp/fluentd/${tag[3]}/${tag[4]}.log
  </template>
</match>
```

ご検討いただけますよう、よろしくお願いいたします。
