### PR TITLE
Add parts_range_separator

### DIFF
--- a/lib/fluent/plugin/out_forest.rb
+++ b/lib/fluent/plugin/out_forest.rb
@@ -6,7 +6,7 @@ class Fluent::ForestOutput < Fluent::MultiOutput
   config_param :add_prefix, :string, :default => nil
   config_param :hostname, :string, :default => `hostname`.chomp
   config_param :escape_tag_separator, :string, :default => '_'
-
+  config_param :parts_range_separator, :string, :default => '.'
   attr_reader :outputs
 
   # Define `log` method for v0.10.42 or earlier
@@ -78,7 +78,7 @@ class Fluent::ForestOutput < Fluent::MultiOutput
           exclude_end = (matched[:range_type] == '...')
           range = Range.new(matched[:first].to_i, matched[:last].to_i, exclude_end)
           if tag_parts[range]
-            tag_parts[range].join(".")
+            tag_parts[range].join(@parts_range_separator)
           else
             log.warn "out_forest: missing placeholder. tag:#{tag} placeholder:#{tag_parts_matched} conf:#{k} #{v}"
             nil


### PR DESCRIPTION
This variable used in accessing `__TAG_PARTS__` with range index. Instead of joining with `.`, it will join with `parts_range_separator`, which defaults to `.`.

Hence, with tag `td.apache.access` and `parts_range_separator` equal to `_`, the result for **TAG_PARTS**[1..-1] will be apache_access.
It will be useful if people want to use parts of tags as folder name, by setting value of `parts_range_separator` with `/`
