### PR TITLE
Rescue ScriptError when planting a subtype

### DIFF
--- a/lib/fluent/plugin/out_forest.rb
+++ b/lib/fluent/plugin/out_forest.rb
@@ -141,7 +141,7 @@ class Fluent::ForestOutput < Fluent::MultiOutput
       log.error e.backtrace.join("\n")
       log.error "Cannot output messages with tag '#{tag}'"
       output = nil
-    rescue StandardError => e
+    rescue StandardError, ScriptError => e
       log.error "failed to configure/start sub output #{@subtype}: #{e.message}"
       log.error e.backtrace.join("\n")
       log.error "Cannot output messages with tag '#{tag}'"


### PR DESCRIPTION
If the plugin specified `@subtype` raises errors which are subclasses of `ScriptError`, there is no error logged.
Catching `Exception` class is too broad, so I just add `ScriptError` to `raise` when planting a subtype.

I faced the problem with `#<LoadError: cannot load such file -- bigdecimal/util>` when loading fluent-plugin-bigquery on an Alpine-based Docker image.