### PR TITLE
travis: Drop Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0


### PR DESCRIPTION
fluentd 1.14.0 released recently requires Ruby version >= 2.1.
Now the latest fluentd is installed on tests, so tests with Ruby 2.0.0 in TravisCI fail.

There are two ways to resolve the problem.

1. Dropping Ruby 2.0.0 from `.travis.yml`
2. Set a fluentd version on `fluent-plugin-forest.gemspec`

I think it's better to choose 1 to support old fluentd in this plugin.

I noticed this error on #28.